### PR TITLE
Re-order include directives so that windows headers are before R.

### DIFF
--- a/inst/include/imager.h
+++ b/inst/include/imager.h
@@ -9,6 +9,8 @@
 #error "The file 'Rcpp.h' should not be included. Please correct to include only 'imager.h'."
 #endif
 
+#include "CImg.h"
+
 #include <R.h>
 #include <Rcpp.h>
 
@@ -24,7 +26,6 @@
 #define cimg_test_abort2() Rcpp::checkUserInterrupt()
 #endif // #ifdef cimg_use_openmp
 
-#include "CImg.h"
 #undef _X
 #undef _Y
 #undef _Z


### PR DESCRIPTION
This fixes a build error with LLVM on Windows:

```
RcppExports.cpp:1768:5: error: no matching function for call to 'R_useDynamicSymbols'
 1768 |     R_useDynamicSymbols(dll, FALSE);
      |     ^~~~~~~~~~~~~~~~~~~
```
the problem is that first R headers are included, which have a typedef for FALSE (as enum). Then, Windows headers are included, which have a #define for FALSE (as 0). Then, R C++ code is compiled, which needs FALSE to be that enum, but it is instead the 0, hence the failure. This patch re-orders the include directives that cause it.

Please note the general recommendation in Writing R Extensions that system headers should be included before R headers.