### PR TITLE
Update linking for Rtools44. Use pkg-config when available.

### DIFF
--- a/src/Makevars.ucrt
+++ b/src/Makevars.ucrt
@@ -1,4 +1,14 @@
 PKG_CPPFLAGS += -I../inst/include -DSTRICT_R_HEADERS -Dcimg_use_r -DCIMG_COMPILING -Dcimg_use_fftw3_singlethread -Dcimg_use_tiff  -Dcimg_use_rng -Dcimg_verbosity=1 -fpermissive -I$(LIB_TIFF)/include -I$(LIB_FFTW)/include 
 PKG_CXXFLAGS += $(SHLIB_OPENMP_CXXFLAGS)
-LIBSHARPYUV = $(or $(and $(wildcard $(R_TOOLS_SOFT)/lib/libsharpyuv.a),-lsharpyuv),)
-PKG_LIBS += -L$(LIB_TIFF)/lib -ltiff  -ljpeg -lz -lzstd -lwebp $(LIBSHARPYUV) -llzma -L$(LIB_FFTW)/lib -lgdi32 -lfftw3 $(RCPP_LDFLAGS) $(SHLIB_OPENMP_CXXFLAGS)
+
+ifeq (,$(shell pkg-config --version 2>/dev/null))
+  LIBSHARPYUV = $(or $(and $(wildcard $(R_TOOLS_SOFT)/lib/libsharpyuv.a),-lsharpyuv),)
+  LIBDEFLATE = $(or $(and $(wildcard $(R_TOOLS_SOFT)/lib/libdeflate.a),-ldeflate),)
+  LIBLERC = $(or $(and $(wildcard $(R_TOOLS_SOFT)/lib/liblerc.a),-llerc),)
+  PKG_LIBS += -L$(LIB_TIFF)/lib -ltiff $(LIBLERC) -ljpeg -lz -lzstd -lwebp $(LIBSHARPYUV) $(LIBDEFLATE) -llzma -L$(LIB_FFTW)/lib -lgdi32 -lfftw3 $(RCPP_LDFLAGS) $(SHLIB_OPENMP_CXXFLAGS)
+else
+  PKG_LIBS = $(shell pkg-config --libs libtiff-4) \
+             -lgdi32 $(RCPP_LDFLAGS) $(SHLIB_OPENMP_CXXFLAGS)
+  PKG_CPPFLAGS += $(shell pkg-config --cflags libtiff-4)
+endif
+


### PR DESCRIPTION
This updates the linking on Windows to use for compatibility with upcoming version of Rtools. It uses pkg-config, when available, to reduce the frequency of required updates.