### PR TITLE
Add support for the .webp image format directly

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,10 +25,18 @@ BugReports: https://github.com/asgr/imager/issues
 SystemRequirements: fftw3, libtiff, X11
 LinkingTo: Rcpp
 LazyData: true
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Suggests:
+    Cairo,
+    dplyr,
+    ggplot2,
     knitr,
-    rmarkdown, ggplot2, dplyr, scales,
-    testthat, raster, spatstat.geom, magick, Cairo
+    magick,
+    raster,
+    rmarkdown,
+    scales,
+    testthat,
+    spatstat.geom,
+    webp
 VignetteBuilder: knitr
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# imager development version
+
+* Added support for .webp format
+
 # imager 0.41.2 Minor release
 
 * Fixed bug in imsub: imsub had a nasty side-effect, that effectively redefined variables "x",y","z", and "cc" if they happened to exist in the current environment. 

--- a/man/load.image.Rd
+++ b/man/load.image.Rd
@@ -13,12 +13,15 @@ load.image(file)
 an object of class 'cimg'
 }
 \description{
-PNG, JPEG and BMP are supported via the readbitmap package. You'll need to install ImageMagick for other formats. If the path is actually a URL, it should start with http(s) or ftp(s).
+PNG, JPEG and BMP are supported via the readbitmap package, WEBP is
+supported via the webp package (with ImageMagick backup). You'll need to
+install ImageMagick for other formats. If the path is actually a URL, it
+should start with http(s) or ftp(s).
 }
 \examples{
 \dontshow{cimg.limit.openmp()}
 #Find path to example file from package
-fpath <- system.file('extdata/Leonardo_Birds.jpg',package='imager') 
+fpath <- system.file('extdata/Leonardo_Birds.jpg',package='imager')
 im <- load.image(fpath)
 plot(im)
 #Load the R logo directly from the CRAN webpage

--- a/man/make.video.Rd
+++ b/man/make.video.Rd
@@ -35,7 +35,7 @@ save.video(im, fname, ...)
 }
 \description{
 You need to have ffmpeg on your path for this to work. This function uses ffmpeg to combine individual frames into a video.
-save.video can be called directly with an image or image list as input. 
+save.video can be called directly with an image or image list as input.
 make.video takes as argument a directory that contains a sequence of images representing individual frames to be combined into a video.
 }
 \section{Functions}{


### PR DESCRIPTION
This adds support for the .webp format via the webp package (if available) with ImageMagick as a backup.