### PR TITLE
Fix for upcoming testthat 3.3.0 release

### DIFF
--- a/tests/testthat/test_load_save_videos.R
+++ b/tests/testthat/test_load_save_videos.R
@@ -12,7 +12,7 @@ test_that("load_and_save_videos",{
         
             ff <- tempfile(fileext=".mp4")
             save.video(im,ff)
-            expect(file_test("-f",ff),TRUE)
+            expect_true(file_test("-f",ff))
             im2 <- load.video(ff)
             unlink(ff)
             expect_equal(im,im2)


### PR DESCRIPTION
`expect()` now checks its inputs highlighting that you accidentally used it instead of the correct expectation