### PR TITLE
Remove redundant exception handling

### DIFF
--- a/src/drawing.cpp
+++ b/src/drawing.cpp
@@ -6,13 +6,7 @@ using namespace cimg_library;
 NumericVector bucket_fill(NumericVector im,int x,int y,int z,NumericVector color,  float opacity=1,float sigma=0,bool high_connexity=false)
 {
   CId img = as<CId >(im);
-  try{
-    img.draw_fill(x-1,y-1,z-1,color.begin(),opacity,sigma,high_connexity);
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-    
-  }
+  img.draw_fill(x-1,y-1,z-1,color.begin(),opacity,sigma,high_connexity);
   return wrap(img);
 }
 
@@ -23,15 +17,7 @@ LogicalVector bucket_select(NumericVector im,int x,int y,int z,float sigma=0,boo
   CIb out(img,"xyzc");
   NumericVector color(img.spectrum());
   float opacity=1;
-
-  try{
-    img.draw_fill(x-1,y-1,z-1,color.begin(),opacity,out,sigma,high_connexity);
-  
-
-  }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-  }
+  img.draw_fill(x-1,y-1,z-1,color.begin(),opacity,out,sigma,high_connexity);
   return wrap(out);
 }
 

--- a/src/filtering.cpp
+++ b/src/filtering.cpp
@@ -23,14 +23,7 @@ using namespace cimg_library;
 NumericVector deriche(NumericVector im,float sigma,int order=0,char axis = 'x',bool neumann=false)
 {
   CId img = as<CId >(im);
-  try{
-      img.deriche(sigma,order,axis,neumann);
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-    
-  }
-
+  img.deriche(sigma,order,axis,neumann);
   return wrap(img);
 }
 
@@ -64,13 +57,7 @@ NumericVector deriche(NumericVector im,float sigma,int order=0,char axis = 'x',b
 NumericVector vanvliet(NumericVector im,float sigma,int order=0,char axis = 'x',bool neumann=false)
 {
   CId img = as<CId >(im);
-  try{
-    img.vanvliet(sigma,order,axis,neumann);
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-    
-  }
+  img.vanvliet(sigma,order,axis,neumann);
   return wrap(img);
 }
 
@@ -78,13 +65,7 @@ NumericVector vanvliet(NumericVector im,float sigma,int order=0,char axis = 'x',
 // [[Rcpp::export]]
 NumericVector isoblur_(NumericVector im,float sigma,bool neumann=true,bool gaussian=false) {
   CId img = as< CId >(im);
-  try{
-    img.blur(sigma,neumann,gaussian);
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-    
-  }
+  img.blur(sigma,neumann,gaussian);
   return wrap(img);
 }
 
@@ -108,13 +89,7 @@ NumericVector isoblur_(NumericVector im,float sigma,bool neumann=true,bool gauss
 // [[Rcpp::export]]
 NumericVector medianblur(NumericVector im,int n, float threshold=0) {
   CId img = as<CId >(im);
-  try{
-    img.blur_median(n,threshold);
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-    
-  }
+  img.blur_median(n,threshold);
   return wrap(img);
 }
 
@@ -131,13 +106,7 @@ NumericVector medianblur(NumericVector im,int n, float threshold=0) {
 // [[Rcpp::export]]
 NumericVector boxblur(NumericVector im,float boxsize,bool neumann=true) {
   CId img = as<CId >(im);
-  try{
-    img.blur_box(boxsize,neumann);
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-    
-  }
+  img.blur_box(boxsize,neumann);
   return wrap(img);
 }
 
@@ -153,12 +122,7 @@ NumericVector boxblur(NumericVector im,float boxsize,bool neumann=true) {
 // [[Rcpp::export]]
 NumericVector imlap(NumericVector im) {
   CId img = as<CId >(im);
-  try{
-    img.laplacian();
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-  }
+  img.laplacian();
   return wrap(img);
 }
 
@@ -180,13 +144,7 @@ NumericVector imlap(NumericVector im) {
 // [[Rcpp::export]]
 NumericVector boxblur_xy(NumericVector im,float sx,float sy,bool neumann=true) {
   CId img = as<CId >(im);
-  try{
-    img.blur_box(sx,sy,0,neumann);
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-    
-  }
+  img.blur_box(sx,sy,0,neumann);
   return wrap(img);
 }
 
@@ -216,13 +174,7 @@ NumericVector boxblur_xy(NumericVector im,float sx,float sy,bool neumann=true) {
 NumericVector correlate(NumericVector im,NumericVector filter, bool dirichlet=true,bool normalise = false) {
   CId img = as<CId >(im);
   CId flt = as<CId >(filter);
-  try{
-    img.correlate(flt,!dirichlet,normalise);
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-    
-  }
+  img.correlate(flt,!dirichlet,normalise);
   return wrap(img);
 }
 
@@ -233,13 +185,7 @@ NumericVector correlate(NumericVector im,NumericVector filter, bool dirichlet=tr
 NumericVector convolve(NumericVector im,NumericVector filter, bool dirichlet=true,bool normalise = false) {
   CId img = as<CId >(im);
   CId flt = as<CId >(filter);
-  try{
-    img.convolve(flt,!dirichlet,normalise);
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-    
-  }
+  img.convolve(flt,!dirichlet,normalise);
   return wrap(img);
 }
 
@@ -250,13 +196,7 @@ NumericVector sharpen(NumericVector im,float amplitude,
 		float alpha = 0,float sigma = 0)
  {
    CId img = as<CId >(im);
-   try{
-     img.sharpen(amplitude,sharpen_type,edge,alpha,sigma);
-     }
-   catch(CImgException &e){
-     forward_exception_to_r(e);
-     
-   }
+   img.sharpen(amplitude,sharpen_type,edge,alpha,sigma);
    return wrap(img);
 }
 
@@ -279,17 +219,8 @@ NumericVector sharpen(NumericVector im,float amplitude,
 List get_gradient(NumericVector im,std::string axes = "",int scheme=3)
 {
    CId img = as<CId >(im);
-   try{
-     CImgList<double> grad = img.get_gradient(axes.c_str(),scheme);
-     return wrap(grad);
-     }
-   catch(CImgException &e){
-     forward_exception_to_r(e);
-     CImgList<double> empty;
-     return wrap(empty);
-   }
-   
-
+   CImgList<double> grad = img.get_gradient(axes.c_str(),scheme);
+   return wrap(grad);
 }
 
 //' Return image hessian.
@@ -299,17 +230,8 @@ List get_gradient(NumericVector im,std::string axes = "",int scheme=3)
 List get_hessian(NumericVector im,std::string axes = "")
 {
    CId img = as<CId >(im);
-
-   try{
-     CImgList<double> hess = img.get_hessian(axes.c_str());
-     return wrap(hess);
-     }
-   catch(CImgException &e){
-     forward_exception_to_r(e);
-     CImgList<double> empty;
-     return wrap(empty); //will never reach here
-   }
-   
+   CImgList<double> hess = img.get_hessian(axes.c_str());
+   return wrap(hess);
 }
 
 //' Compute field of diffusion tensors for edge-preserving smoothing.
@@ -328,13 +250,7 @@ NumericVector diffusion_tensors(NumericVector im,
 				bool is_sqrt = false) 	
 {
   CId img = as<CId >(im);
-  try{
-    img.diffusion_tensors(sharpness,anisotropy,alpha,sigma,is_sqrt);
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-    
-  }
+  img.diffusion_tensors(sharpness,anisotropy,alpha,sigma,is_sqrt);
   return wrap(img);
 }
 
@@ -355,13 +271,7 @@ NumericVector diffusion_tensors(NumericVector im,
 // [[Rcpp::export]]
 NumericVector haar(NumericVector im,bool inverse=false,int nb_scales=1) {
   CId img = as<CId >(im);
-  try{
-    img.haar(inverse,nb_scales);
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-    
-  }
+  img.haar(inverse,nb_scales);
   return wrap(img);
 }
 
@@ -369,13 +279,7 @@ NumericVector haar(NumericVector im,bool inverse=false,int nb_scales=1) {
 List FFT_complex(NumericVector real,NumericVector imag,bool inverse=false,int nb_threads=0) {
   CId rl = as<CId >(real);
   CId img = as<CId >(imag);
-  try{
-    rl.FFT(rl,img,inverse,nb_threads);
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-    
-  }
+  rl.FFT(rl,img,inverse,nb_threads);
   return List::create(_["real"] = wrap(rl),_["imag"] = wrap(img));
 }
 
@@ -383,13 +287,7 @@ List FFT_complex(NumericVector real,NumericVector imag,bool inverse=false,int nb
 List FFT_realim(NumericVector real,bool inverse=false,int nb_threads=0) {
   CId rl = as<CId >(real);
   CId im(rl,"xyzc",0);
-  try{
-    rl.FFT(rl,im,inverse,nb_threads);
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-    
-  }
+  rl.FFT(rl,im,inverse,nb_threads);
   return List::create(_["real"] = wrap(rl),_["imag"] = wrap(im));
 }
 
@@ -397,13 +295,7 @@ List FFT_realim(NumericVector real,bool inverse=false,int nb_threads=0) {
 NumericVector FFT_realout(NumericVector real,NumericVector imag,bool inverse=false,int nb_threads=0) {
   CId rl = as<CId >(real);
   CId img = as<CId >(imag);
-  try{
-    rl.FFT(rl,img,inverse,nb_threads);
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-    
-  }
+  rl.FFT(rl,img,inverse,nb_threads);
   return wrap(rl);
 }
 
@@ -424,13 +316,7 @@ NumericVector displacement(NumericVector sourceIm,NumericVector destIm,float smo
    CId src = as<CId >(sourceIm);
    CId dst = as<CId >(destIm);
    CId out(src,false);
-   try{
-     out.displacement(dst,smoothness,precision,nb_scales,iteration_max,is_backward);
-     }
-   catch(CImgException &e){
-     forward_exception_to_r(e);
-     
-   }
+   out.displacement(dst,smoothness,precision,nb_scales,iteration_max,is_backward);
    return wrap(out);
 }
 
@@ -462,13 +348,7 @@ NumericVector blur_anisotropic(NumericVector im, float amplitude,  float sharpne
                                float gauss_prec=2,  unsigned int interpolation_type=0,
                                bool fast_approx=true) {
   CId img = as<CId >(im);
-  try{
-    img.blur_anisotropic(amplitude,sharpness,anisotropy,alpha,sigma,dl,da,gauss_prec,interpolation_type,fast_approx);
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-    
-  }
+  img.blur_anisotropic(amplitude,sharpness,anisotropy,alpha,sigma,dl,da,gauss_prec,interpolation_type,fast_approx);
   return wrap(img);
 }
 

--- a/src/interpolation.cpp
+++ b/src/interpolation.cpp
@@ -10,8 +10,6 @@ NumericVector interp_xy(NumericVector inp,NumericVector ix,NumericVector iy, int
     double val;
     NumericVector out(n);
 
-  try{
-
     for (int ind = 0; ind < n; ind++)
       {
 	if (cubic)
@@ -25,11 +23,6 @@ NumericVector interp_xy(NumericVector inp,NumericVector ix,NumericVector iy, int
 	out[ind] = val;
       }
     
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-    
-  }
     return wrap(out);
 }
 
@@ -40,8 +33,6 @@ NumericVector interp_xyz(NumericVector inp,NumericVector ix,NumericVector iy,Num
     int n = ix.length();
     double val;
     NumericVector out(n);
-
-  try{
 
     for (int ind = 0; ind < n; ind++)
       {
@@ -56,11 +47,6 @@ NumericVector interp_xyz(NumericVector inp,NumericVector ix,NumericVector iy,Num
 	out[ind] = val;
       }
     
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-    
-  }
     return wrap(out);
 }
 
@@ -73,8 +59,6 @@ NumericVector interp_xyzc(NumericVector inp,NumericVector ix,NumericVector iy,Nu
     double val;
     NumericVector out(n);
 
-  try{
-    
     for (int ind = 0; ind < n; ind++)
       {
 	if (cubic)
@@ -88,11 +72,6 @@ NumericVector interp_xyzc(NumericVector inp,NumericVector ix,NumericVector iy,Nu
 	out[ind] = val;
       }
     
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-    
-  }
   return wrap(out);
 }
 
@@ -103,8 +82,6 @@ NumericVector interp_xyc(NumericVector inp,NumericVector ix,NumericVector iy,int
     int n = ix.length();
     double val;
     NumericVector out(n);
-
-  try{
 
     for (int ind = 0; ind < n; ind++)
       {
@@ -119,10 +96,5 @@ NumericVector interp_xyc(NumericVector inp,NumericVector ix,NumericVector iy,int
 	out[ind] = val;
       }
     
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-    
-  }
   return wrap(out);
 }

--- a/src/morphology.cpp
+++ b/src/morphology.cpp
@@ -30,13 +30,7 @@ NumericVector label(NumericVector im,bool high_connectivity=false,
 double tolerance=0)
 {
     CId img = as<CId >(im);
-  try{
     img.label(high_connectivity,tolerance);
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-    
-  }
   return wrap(img);
 }
 
@@ -45,12 +39,7 @@ NumericVector blabel(LogicalVector im,bool high_connectivity=false)
 {
     CIb img = as<CIb >(im);
     CId out;
-    try{
-      out = img.get_label(high_connectivity,0);
-    }
-    catch(CImgException &e){
-      forward_exception_to_r(e);
-    }
+    out = img.get_label(high_connectivity,0);
     return wrap(out);
 }
 
@@ -80,14 +69,8 @@ NumericVector blabel(LogicalVector im,bool high_connectivity=false)
 // [[Rcpp::export]]
 NumericVector erode(NumericVector im,NumericVector mask, bool boundary_conditions=true,bool real_mode=false) {
   CId img = as<CId >(im);
-  try{
-    CId msk = as<CId >(mask);
-    img.erode(msk,boundary_conditions,real_mode);
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-    
-  }
+  CId msk = as<CId >(mask);
+  img.erode(msk,boundary_conditions,real_mode);
   return wrap(img);
 }
 
@@ -95,13 +78,8 @@ NumericVector erode(NumericVector im,NumericVector mask, bool boundary_condition
 // [[Rcpp::export]]
 LogicalVector berode(LogicalVector im,LogicalVector mask, bool boundary_conditions=true) {
   CIb img = as<CIb >(im);
-  try{
-    CIb msk = as<CIb >(mask);
-    img.erode(msk,boundary_conditions,false);
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-  }
+  CIb msk = as<CIb >(mask);
+  img.erode(msk,boundary_conditions,false);
   return wrap(img);
 }
 
@@ -114,26 +92,14 @@ LogicalVector berode(LogicalVector im,LogicalVector mask, bool boundary_conditio
 // [[Rcpp::export]]
 NumericVector erode_rect(NumericVector im,int sx,int sy,int sz=1) {
   CId img = as<CId >(im);
-  try{
-    img.erode(sx,sy,sz);
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-    
-  }
+  img.erode(sx,sy,sz);
   return wrap(img);
 }
 
 // [[Rcpp::export]]
 LogicalVector berode_rect(LogicalVector im,int sx,int sy,int sz=1) {
   CIb img = as<CIb >(im);
-  try{
-    img.erode(sx,sy,sz);
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-    
-  }
+  img.erode(sx,sy,sz);
   return wrap(img);
 }
 
@@ -144,26 +110,14 @@ LogicalVector berode_rect(LogicalVector im,int sx,int sy,int sz=1) {
 // [[Rcpp::export]]
 NumericVector erode_square(NumericVector im,int size) {
   CId img = as<CId >(im);
-  try{
-    img.erode(size);
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-    
-  }
+  img.erode(size);
   return wrap(img);
 }
 
 // [[Rcpp::export]]
 LogicalVector berode_square(LogicalVector im,int size) {
   CIb img = as<CIb >(im);
-  try{
-    img.erode(size);
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-    
-  }
+  img.erode(size);
   return wrap(img);
 }
 
@@ -174,13 +128,7 @@ LogicalVector berode_square(LogicalVector im,int size) {
 NumericVector dilate(NumericVector im,NumericVector mask, bool boundary_conditions=true,bool real_mode = false) {
   CId img = as<CId >(im);
   CId msk = as<CId >(mask);
-  try{
-    img.dilate(msk,boundary_conditions,real_mode);
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-    
-  }
+  img.dilate(msk,boundary_conditions,real_mode);
   return wrap(img);
 }
 
@@ -188,13 +136,7 @@ NumericVector dilate(NumericVector im,NumericVector mask, bool boundary_conditio
 LogicalVector bdilate(LogicalVector im,LogicalVector mask, bool boundary_conditions=true) {
   CIb img = as<CIb >(im);
   CIb msk = as<CIb >(mask);
-  try{
-    img.dilate(msk,boundary_conditions,false);
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-    
-  }
+  img.dilate(msk,boundary_conditions,false);
   return wrap(img);
 }
 
@@ -204,13 +146,7 @@ LogicalVector bdilate(LogicalVector im,LogicalVector mask, bool boundary_conditi
 // [[Rcpp::export]]
 NumericVector dilate_rect(NumericVector im,int sx,int sy,int sz=1) {
   CId img = as<CId >(im);
-  try{
-    img.dilate(sx,sy,sz);
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-    
-  }
+  img.dilate(sx,sy,sz);
   return wrap(img);
 }
 
@@ -218,12 +154,7 @@ NumericVector dilate_rect(NumericVector im,int sx,int sy,int sz=1) {
 // [[Rcpp::export]]
 LogicalVector bdilate_rect(LogicalVector im,int sx,int sy,int sz=1) {
   CIb img = as<CIb >(im);
-  try{
-    img.dilate(sx,sy,sz);
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-  }
+  img.dilate(sx,sy,sz);
   return wrap(img);
 }
 
@@ -232,26 +163,14 @@ LogicalVector bdilate_rect(LogicalVector im,int sx,int sy,int sz=1) {
 // [[Rcpp::export]]
 NumericVector dilate_square(NumericVector im,int size) {
   CId img = as<CId >(im);
-  try{
-    img.dilate(size);
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-    
-  }
+  img.dilate(size);
   return wrap(img);
 }
 
 // [[Rcpp::export]]
 LogicalVector bdilate_square(LogicalVector im,int size) {
   CIb img = as<CIb >(im);
-  try{
-    img.dilate(size);
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-    
-  }
+  img.dilate(size);
   return wrap(img);
 }
 
@@ -282,13 +201,7 @@ LogicalVector bdilate_square(LogicalVector im,int size) {
 NumericVector watershed(NumericVector im,NumericVector priority, bool fill_lines=true) {
   CId img = as<CId >(im);
   CId pri = as<CId >(priority);
-  try{
-    img.watershed(pri,fill_lines);
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-    
-  }
+  img.watershed(pri,fill_lines);
   return wrap(img);
 }
 
@@ -317,13 +230,7 @@ NumericVector watershed(NumericVector im,NumericVector priority, bool fill_lines
 NumericVector distance_transform(NumericVector im,double value,unsigned int metric=2)
 {
   CId img = as<CId >(im);
-  try{
-    img.distance(value,metric);
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-    
-  }
+  img.distance(value,metric);
   return wrap(img);
 }
 
@@ -333,12 +240,7 @@ NumericVector bdistance_transform(LogicalVector im,bool value=true,unsigned int 
 {
   CIb img = as<CIb >(im);
   CId out;
-  try{
-    out = img.get_distance(value,metric);
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-  }
+  out = img.get_distance(value,metric);
   return wrap(out);
 }
 
@@ -348,15 +250,8 @@ NumericVector bdistance_transform(LogicalVector im,bool value=true,unsigned int 
 // [[Rcpp::export]]
 NumericVector mopening(NumericVector im,NumericVector mask, bool boundary_conditions=true,bool real_mode = false) {
   CId img = as<CId >(im);
-
-  try{
-    CId msk = as<CId >(mask);
-    img.erode(msk,boundary_conditions,real_mode).dilate(msk,boundary_conditions,real_mode);
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-    
-  }
+  CId msk = as<CId >(mask);
+  img.erode(msk,boundary_conditions,real_mode).dilate(msk,boundary_conditions,real_mode);
   return wrap(img);
 }
 
@@ -366,12 +261,7 @@ NumericVector mopening(NumericVector im,NumericVector mask, bool boundary_condit
 // [[Rcpp::export]]
 NumericVector mopening_square(NumericVector im,int size) {
   CId img = as<CId >(im);
-  try{
-    img.erode(size).dilate(size);
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-  }
+  img.erode(size).dilate(size);
   return wrap(img);
 }
 
@@ -380,14 +270,7 @@ NumericVector mopening_square(NumericVector im,int size) {
 // [[Rcpp::export]]
 NumericVector mclosing_square(NumericVector im,int size) {
   CId img = as<CId >(im);
-  
-  try{
-    img.dilate(size).erode(size);
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-    
-  }
+  img.dilate(size).erode(size);
   return wrap(img);
 }
 
@@ -396,15 +279,8 @@ NumericVector mclosing_square(NumericVector im,int size) {
 // [[Rcpp::export]]
 NumericVector mclosing(NumericVector im,NumericVector mask, bool boundary_conditions=true,bool real_mode = false) {
   CId img = as<CId >(im);
-
-  try{
-    CId msk = as<CId >(mask);
-    img.dilate(msk,boundary_conditions,real_mode).erode(msk,boundary_conditions,real_mode);
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-    
-  }
+  CId msk = as<CId >(mask);
+  img.dilate(msk,boundary_conditions,real_mode).erode(msk,boundary_conditions,real_mode);
   return wrap(img);
 }
 

--- a/src/transformations.cpp
+++ b/src/transformations.cpp
@@ -7,14 +7,7 @@ NumericVector autocrop_(NumericVector im,NumericVector color,std::string axes = 
 {
   CId img = as<CId >(im);
   CId out;
-
-  try{
-    out = img.get_autocrop(color.begin(),axes.c_str());
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-    
-  }
+  out = img.get_autocrop(color.begin(),axes.c_str());
    return wrap(out);
 }
 
@@ -25,14 +18,7 @@ NumericVector rotate(NumericVector im,float  	angle,
 {
   CId img = as<CId >(im);
   CId out(img,false);
-
-  try{
-    out.rotate(angle,interpolation,boundary);
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-    
-  }
+  out.rotate(angle,interpolation,boundary);
    return wrap(out);
 }
 
@@ -58,15 +44,7 @@ NumericVector rotate_xy(NumericVector im,
 {
   CId img = as<CId >(im);
   CId out(img,false);
-
-
-  try{
-    out.rotate(angle,cx,cy,interpolation,boundary_conditions);
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-    
-  }
+  out.rotate(angle,cx,cy,interpolation,boundary_conditions);
    return wrap(out);
 }
 
@@ -82,14 +60,7 @@ NumericVector rotate_xy(NumericVector im,
 NumericVector mirror(NumericVector im,char axis)
 {
   CId img = as<CId >(im);
-    
-  try{
-    img.mirror(axis);
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-    
-  }
+  img.mirror(axis);
    return wrap(img);
 }
 
@@ -107,14 +78,7 @@ NumericVector mirror(NumericVector im,char axis)
 NumericVector permute_axes(NumericVector im,std::string perm)
 {
   CId img = as<CId >(im);
-  try{
-
-    img.permute_axes(perm.c_str());
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-    
-  }
+  img.permute_axes(perm.c_str());
    return wrap(img);
 }
 
@@ -125,14 +89,7 @@ NumericVector resize_doubleXY(NumericVector im)
 {
   CId img = as<CId >(im);
   CId out(img,false);
-
-  try{
-    out.resize_doubleXY();
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-    
-  }
+  out.resize_doubleXY();
    return wrap(out);
 }
 
@@ -143,14 +100,7 @@ NumericVector resize_halfXY(NumericVector im)
 {
   CId img = as<CId >(im);
   CId out(img,false);
-
-  try{
-    out.resize_halfXY();
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-    
-  }
+  out.resize_halfXY();
    return wrap(out);
 }
 
@@ -162,14 +112,7 @@ NumericVector resize_tripleXY(NumericVector im)
 {
   CId img = as<CId >(im);
   CId out(img,false);
-
-  try{
-    out.resize_tripleXY();
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-    
-  }
+  out.resize_tripleXY();
    return wrap(out);
 }
 
@@ -196,14 +139,7 @@ NumericVector imshift(NumericVector im, int delta_x=0,  int delta_y=0,  int delt
                     int boundary_conditions=0)
 {
   CId img = as<CId >(im);
-
-  try{
-    img.shift(delta_x,delta_y,delta_z,delta_c,boundary_conditions);
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-    
-  }
+  img.shift(delta_x,delta_y,delta_z,delta_c,boundary_conditions);
    return wrap(img);
 }
 
@@ -241,14 +177,8 @@ NumericVector resize(NumericVector im, int size_x=-100,  int size_y=-100,
 {
   CId img = as<CId >(im);
   CId out(img,false);
-  try{
-    out.resize(size_x,size_y,size_z,size_c,interpolation_type,boundary_conditions,
+  out.resize(size_x,size_y,size_z,size_c,interpolation_type,boundary_conditions,
 	       centering_x,centering_y,centering_z,centering_c);
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-    
-  }
    return wrap(out);
 }
 
@@ -276,16 +206,9 @@ NumericVector warp(NumericVector im,NumericVector warpfield,
 {
     CId img = as<CId >(im);
     CId wrp = as<CId >(warpfield);
-    try{
-      if ((mode==0) || (mode == 2)) //In R coordinates start at 1
-	{
-	  wrp--;
-	}
-      img.warp(wrp,mode,interpolation,boundary_conditions);
-    }
-    catch(CImgException &e){
-      forward_exception_to_r(e);
-    }
+    if ((mode==0) || (mode == 2)) //In R coordinates start at 1
+	    wrp--;
+    img.warp(wrp,mode,interpolation,boundary_conditions);
     return wrap(img);
 }
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -7,28 +7,15 @@ using namespace cimg_library;
 
 // [[Rcpp::export]]
 NumericVector load_image(std::string fname) {
-  try{
-    CId image(fname.c_str());
-    return wrap(image);
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-    NumericVector empty;
-    return empty; //won't happen
-  }
+  CId image(fname.c_str());
+  return wrap(image);
 }
 
 
 // [[Rcpp::export]]
 void save_image(NumericVector im, std::string fname) {
-  try{
-    CId image = as<CId >(im);
-    image.save(fname.c_str());
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-  }
-  return;
+  CId image = as<CId >(im);
+  image.save(fname.c_str());
 }
 
 //' Split an image along a certain axis (producing a list)
@@ -41,48 +28,27 @@ void save_image(NumericVector im, std::string fname) {
 // [[Rcpp::export]]
 List im_split(NumericVector im,char axis,int nb=-1)
 {
-  try{
-    CId img = as<CId >(im);
-    CImgList<double> out;
-    out = img.get_split(axis,nb);
-    return wrap(out);
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-    List empty;
-    return empty; //won't happen
-  }
+  CId img = as<CId >(im);
+  CImgList<double> out;
+  out = img.get_split(axis,nb);
+  return wrap(out);
 }
 
 
 // [[Rcpp::export]]
 NumericVector im_append(List imlist,char axis)
 {
-  try{
-      CImgList<double> ilist = sharedCImgList(imlist);
-      CId out(ilist.get_append(axis));
-      return wrap(out);
-  }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-    NumericVector empty;
-    return empty;
-  }
+  CImgList<double> ilist = sharedCImgList(imlist);
+  CId out(ilist.get_append(axis));
+  return wrap(out);
 }
 
 // [[Rcpp::export]]
 LogicalVector px_append(List imlist,char axis)
 {
-  try{
-      CImgList<int> ilist = sharedCImgList_bool(imlist);
-      CIb out(ilist.get_append(axis));
-      return wrap(out);
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-    LogicalVector empty;
-    return empty;
-  }
+  CImgList<int> ilist = sharedCImgList_bool(imlist);
+  CIb out(ilist.get_append(axis));
+  return wrap(out);
 }
 
 //' Extract a numerical summary from image patches, using CImg's mini-language
@@ -253,15 +219,8 @@ List extract_patches3D(NumericVector im,IntegerVector cx,IntegerVector cy,Intege
 NumericVector draw_image(NumericVector im,NumericVector sprite,int x=0,int y = 0, int z = 0,float opacity = 1)
 {
   CId img = as<CId >(im);
-
-  try{
-    CId spr = as<CId >(sprite);
-    img.draw_image(x,y,z,spr,opacity);
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-    
-  }
+  CId spr = as<CId >(sprite);
+  img.draw_image(x,y,z,spr,opacity);
   return wrap(img);
 }
 
@@ -276,22 +235,14 @@ List do_patchmatch(NumericVector im1,NumericVector im2,
 			  float occ_penalization,
                           NumericVector guide)
 {
-  try{
-    CId img1 = as<CId >(im1);
-    CId img2 = as<CId >(im2);
-    CId g = as<CId >(guide);
-    CId mscore(img1,"xyzc");
-    CImg<int> out = img1.matchpatch(img2,patch_width,patch_height,patch_depth,
+  CId img1 = as<CId >(im1);
+  CId img2 = as<CId >(im2);
+  CId g = as<CId >(guide);
+  CId mscore(img1,"xyzc");
+  CImg<int> out = img1.matchpatch(img2,patch_width,patch_height,patch_depth,
 				    nb_iterations,nb_randoms,occ_penalization,g,mscore);
-    CId outfl(out);
-    return List::create(_["warp"] = wrap(outfl),_["score"] = wrap(mscore));
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-    List empty;
-    return empty; //won't happen
-  }
-
+  CId outfl(out);
+  return List::create(_["warp"] = wrap(outfl),_["score"] = wrap(mscore));
 }
 
 
@@ -352,17 +303,10 @@ bool has_omp()
 // [[Rcpp::export]]
 List px_split(LogicalVector im,char axis,int nb=-1)
 {
-  try{
-    CIb img = as<CIb >(im);
-    CImgList<bool> out;
-    out = img.get_split(axis,nb);
-    return wrap(out);
-    }
-  catch(CImgException &e){
-    forward_exception_to_r(e);
-    List empty;
-    return empty; //won't happen
-  }
+  CIb img = as<CIb >(im);
+  CImgList<bool> out;
+  out = img.get_split(axis,nb);
+  return wrap(out);
 }
 
 


### PR DESCRIPTION
Exception handling is provided by Rcpp, no need to add another try/catch layer.

(BTW, Rcpp also calls `wrap` for you, so `return wrap(out)` is also redundant)